### PR TITLE
fix: link click on closed dropdown

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,7 +42,7 @@ function App() {
         >
           Add to Calendar
         </button>
-        <ul className={`${isOpen ? 'opacity-100' : 'opacity-0' } absolute top-full left-0 min-w-full border shadow-lg py-2 px-1 transition-opacity`}>
+        <ul className={`${isOpen ? 'opacity-100' : 'opacity-0 invisible' } absolute top-full left-0 min-w-full border shadow-lg py-2 px-1 transition-opacity`}>
           <li>
             <a href={icsUrl} target="_blank" className="flex items-center gap-2 text-zinc-800 hover:bg-zinc-50 px-4 py-2 whitespace-nowrap">
               <svg className="w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">


### PR DESCRIPTION
**Bug**: When dropdown is closed, user can click on the links, even links are not visible on the screen.

See the bug image attached below:

![image](https://github.com/colbyfayock/my-calendar-link/assets/31031186/82f0813c-6f32-4bac-b876-af0de59cfb24)
